### PR TITLE
Mix Signal and StateSignal proposal 

### DIFF
--- a/libraries/iso-signal/src/_index.ts
+++ b/libraries/iso-signal/src/_index.ts
@@ -2,55 +2,39 @@
 // ----------------------------------------------------------------------------- STRUCT
 
 // Type of a micro signal handler
-export type TSignalHandler <G extends any[], E = void|any> = (...rest:G) => E
+export type TSignalHandler <G = void|any, E = void|any> = (param:G) => E
 
 // Default interface of a micro signal
-export interface ISignal <G extends any[] = any[], E = void|any>
+export interface ISignal <G = void|any, E = void|any>
 {
 	on: ( handler:TSignalHandler<G, E> ) => () => void
 	off: ( handler:TSignalHandler<G, E> ) => void
-	dispatch: ( ...rest:G ) => E[]
+	dispatch: ( param:G ) => E[]
 	clear: () => void
 	readonly listeners : TSignalHandler<G, E>[]
+	readonly state: G;
 }
 
-// Extended interface of a state signal
-export interface IStateSignal <G extends any = any, E = void|any> extends ISignal<[G], E>
-{
-	dispatch: ( state:G ) => E[]
-	readonly state : G
-}
+// ----------------------------------------------------------------------------- MIX SIGNAL & STATE SIGNAL
 
-// ----------------------------------------------------------------------------- CLASSIC SIGNAL
-
-export function Signal <G extends any[] = any, E = void|any> ():ISignal<G, E> {
-	let _listeners = []
-	const off = ( handler ) => _listeners.filter( s => s != handler )
+export function Signal<G = void | any, E = void | any>(
+	_state: G = null,
+): ISignal<G, E> {
+	let _listeners = [];
+	const off = (handler) => _listeners.filter((s) => s != handler);
 	return {
-		on ( handler:TSignalHandler<G> ) {
-			_listeners.push( handler )
-			return () => off( handler )
+		on(handler: TSignalHandler<G>) {
+			_listeners.push(handler);
+			return () => off(handler);
 		},
 		off,
-		dispatch: ( ...rest:G ) => _listeners.map( h => h(...rest) ),
-		clear () { _listeners = [] },
-		get listeners () { return _listeners }
-	}
-}
-
-// ----------------------------------------------------------------------------- STATE SIGNAL
-
-export function StateSignal
-	<G extends any, E = void|any>
-	( _state:G = null, _signal = Signal<[G], E>() )
-	:IStateSignal<G, E>
-{
-	return {
-		..._signal,
-		dispatch ( state:G ) {
-			_state = state;
-			return _signal.dispatch( state )
+		dispatch: (param: G) => {
+			_state = param;
+			return _listeners.map((h) => h(param))
 		},
-		get state ():G { return _state }
-	}
+		clear() { _listeners = []  },
+		get listeners() { return _listeners },
+		get state(): G { return _state; }
+	};
 }
+


### PR DESCRIPTION
L'idée est de n'avoir plus q'une seule fonction signal qui pourrait avoir un state par défaut ou non. Les deux fonctionnons étant très semblable, cela permet de ne pas de se poser la question de laquelle on doit importer.

Cela soulève et "fixe" un autre sujet que je trouve étrange actuellement : 

Le param ...rest oblige à typer `<[string]>Signal()` au lieu de ce qui parait plus intuitif `<string>Signal()`. Cela nécessitera de passer au dispatch manuellement un tableau si l'on veut dispatcher plusieurs valeurs, et ainsi typer un tableau au départ ; Mais encore une fois plus facile à appréhender je trouve.

Qu'est ce que tu en penses ?


[example sandbox](https://codesandbox.io/s/throbbing-silence-7noln?file=/src/index.ts:0-251)
